### PR TITLE
drop live capability

### DIFF
--- a/data.json
+++ b/data.json
@@ -1,0 +1,2007 @@
+{
+	"timestamp": "2016-06-13T11:23:04.255Z",
+	"devices": [
+		{
+			"name": "acer iconia tab a1-810",
+			"platform": "android",
+			"os": "4.2.2",
+			"size": "768x1024",
+			"release": "2013-05"
+		},
+		{
+			"name": "acer iconia tab a100",
+			"platform": "android",
+			"os": "4.0.3",
+			"size": "800x1280",
+			"release": "2011-04"
+		},
+		{
+			"name": "acer iconia tab a101",
+			"platform": "android",
+			"os": "3.2.1",
+			"size": "600x1024",
+			"release": "2011-05"
+		},
+		{
+			"name": "acer iconia tab a200",
+			"platform": "android",
+			"os": "4.0.3",
+			"size": "800x1280",
+			"release": "2012-01"
+		},
+		{
+			"name": "acer iconia tab a500",
+			"platform": "android",
+			"os": "4.0.3",
+			"size": "648x1280",
+			"release": "2011-04"
+		},
+		{
+			"name": "acer iconia tab a501",
+			"platform": "android",
+			"os": "3.2",
+			"size": "800x1280",
+			"release": "2011-04"
+		},
+		{
+			"name": "acer liquid e2",
+			"platform": "android",
+			"os": "4.2.1",
+			"size": "360x640",
+			"release": "2013-05"
+		},
+		{
+			"name": "ainol novo 7 elf 2",
+			"platform": "android",
+			"os": "4.0.3",
+			"size": "496x1024",
+			"release": "2012-06"
+		},
+		{
+			"name": "alcatel one touch idol x",
+			"platform": "android",
+			"os": "4.2.2",
+			"size": "480x800",
+			"release": "2013-07"
+		},
+		{
+			"name": "alcatel one touch t10",
+			"platform": "android",
+			"os": "4.0.3",
+			"size": "480x800",
+			"release": "2013-03"
+		},
+		{
+			"name": "alcatel one touch 903",
+			"platform": "android",
+			"os": "2.3.6",
+			"size": "320x427",
+			"release": "2012-08"
+		},
+		{
+			"name": "alcatel (vodafone) smart mini 875",
+			"platform": "android",
+			"os": "4.1.1",
+			"size": "320x480",
+			"release": "2013-07"
+		},
+		{
+			"name": "amicroe 7 touchtab ii",
+			"platform": "android",
+			"os": "4.0.4",
+			"size": "480x800",
+			"release": "2013-01"
+		},
+		{
+			"name": "amicroe 9.7 touchtab iv",
+			"platform": "android",
+			"os": "4.1.1",
+			"size": "768x1024",
+			"release": "2013-05"
+		},
+		{
+			"name": "archos 70b (it2)",
+			"platform": "android",
+			"os": "3.2.1",
+			"size": "600x1024",
+			"release": "2012-02"
+		},
+		{
+			"name": "archos 80g9",
+			"platform": "android",
+			"os": "3.2",
+			"size": "768x1024",
+			"release": "2011-09"
+		},
+		{
+			"name": "arnova 10b g3",
+			"platform": "android",
+			"os": "4.0.3",
+			"size": "600x1024",
+			"release": "2012-05"
+		},
+		{
+			"name": "arnova 7 g2",
+			"platform": "android",
+			"os": "2.3.1",
+			"size": "480x800",
+			"release": "2011-09"
+		},
+		{
+			"name": "arnova 7f g3",
+			"platform": "android",
+			"os": "4.0.3",
+			"size": "640x1067",
+			"release": "2012-11"
+		},
+		{
+			"name": "arnova 8c g3",
+			"platform": "android",
+			"os": "4.0.3",
+			"size": "800x1067",
+			"release": "2012-11"
+		},
+		{
+			"name": "asus b1-a71",
+			"platform": "android",
+			"os": "4.1.2",
+			"size": "600x1024",
+			"release": "2013-01"
+		},
+		{
+			"name": "asus fonepad",
+			"platform": "android",
+			"os": "4.1.2",
+			"size": "601x962",
+			"release": "2013-04"
+		},
+		{
+			"name": "asus memo pad me172v",
+			"platform": "android",
+			"os": "4.1.1",
+			"size": "600x1024",
+			"release": "2013-01"
+		},
+		{
+			"name": "asus memo pad fhd10/me302c 10.1",
+			"platform": "android",
+			"os": "4.2.2",
+			"size": "800x1280",
+			"release": "2013-08"
+		},
+		{
+			"name": "asus padfone",
+			"platform": "android",
+			"os": "4.0",
+			"size": "800x1128",
+			"release": "2012-06"
+		},
+		{
+			"name": "asus transformer pad tf300t",
+			"platform": "android",
+			"os": "4.0.3",
+			"size": "800x1280",
+			"release": "2012-04"
+		},
+		{
+			"name": "asus transformer tf101",
+			"platform": "android",
+			"os": "3.1",
+			"size": "800x1280",
+			"release": "2011-04"
+		},
+		{
+			"name": "asus vivo",
+			"platform": "windows rt",
+			"os": "8.0",
+			"size": "768x1366",
+			"release": "2012-11"
+		},
+		{
+			"name": "barnes &amp; noble nook hd",
+			"platform": "android",
+			"os": "4.0.4",
+			"size": "600x960",
+			"release": "2012-11"
+		},
+		{
+			"name": "bauhn amid-972xs",
+			"platform": "android",
+			"os": "4.0.3",
+			"size": "768x1024",
+			"release": "2012-09"
+		},
+		{
+			"name": "bauhn amid-9743g",
+			"platform": "android",
+			"os": "4.1.2",
+			"size": "768x1024",
+			"release": "2013-02"
+		},
+		{
+			"name": "bauhn asp-5000h",
+			"platform": "android",
+			"os": "4.2",
+			"size": "360x640",
+			"release": "2013-09"
+		},
+		{
+			"name": "blackberry 9520",
+			"platform": "blackberry os",
+			"os": "5",
+			"size": "345x691",
+			"release": "2009-11"
+		},
+		{
+			"name": "blackberry bold 9000",
+			"platform": "blackberry os",
+			"os": "4.0.0.223",
+			"size": "480x-",
+			"release": "2008-08"
+		},
+		{
+			"name": "blackberry bold 9780",
+			"platform": "blackberry os",
+			"os": "6.0.0.110",
+			"size": "480x-",
+			"release": "2010-11"
+		},
+		{
+			"name": "blackberry bold 9790",
+			"platform": "blackberry os",
+			"os": "7.0.0.528",
+			"size": "320x-",
+			"release": "2011-12"
+		},
+		{
+			"name": "blackberry bold 9900",
+			"platform": "blackberry os",
+			"os": "7.1.0.342",
+			"size": "356x-",
+			"release": "2011-08"
+		},
+		{
+			"name": "blackberry curve 9300",
+			"platform": "blackberry os",
+			"os": "5.0.0.716",
+			"size": "311x-",
+			"release": "2010-08"
+		},
+		{
+			"name": "blackberry curve 9300",
+			"platform": "blackberry os",
+			"os": "6.0.0.448",
+			"size": "320x-",
+			"release": "2010-08"
+		},
+		{
+			"name": "blackberry curve 9320",
+			"platform": "blackberry os",
+			"os": "7.1.0.569",
+			"size": "320x-",
+			"release": "2010-05"
+		},
+		{
+			"name": "blackberry curve 9360",
+			"platform": "blackberry os",
+			"os": "7.0.0.530",
+			"size": "320x-",
+			"release": "2011-08"
+		},
+		{
+			"name": "blackberry curve 9380",
+			"platform": "blackberry os",
+			"os": "7.0.0.513",
+			"size": "320x406",
+			"release": "2011-12"
+		},
+		{
+			"name": "blackberry playbook",
+			"platform": "blackberry tablet os",
+			"os": "2.1.0",
+			"size": "600x1024",
+			"release": "2011-04"
+		},
+		{
+			"name": "blackberry torch 9800",
+			"platform": "blackberry os",
+			"os": "6.0.0.353",
+			"size": "360x480",
+			"release": "2010-08"
+		},
+		{
+			"name": "blackberry torch 9810",
+			"platform": "blackberry os",
+			"os": "7.0.0.296",
+			"size": "320x-",
+			"release": "2011-08"
+		},
+		{
+			"name": "blackberry torch 9860",
+			"platform": "blackberry os",
+			"os": "7.0.0.579",
+			"size": "320x505",
+			"release": "2011-09"
+		},
+		{
+			"name": "blackberry q10",
+			"platform": "blackberry os",
+			"os": "10.1.0.1910",
+			"size": "346x-",
+			"release": "2013-04"
+		},
+		{
+			"name": "blackberry z10",
+			"platform": "blackberry os",
+			"os": "10.0.10.690",
+			"size": "342x570",
+			"release": "2013-02"
+		},
+		{
+			"name": "dell venue 8",
+			"platform": "windows 8",
+			"os": "8.1",
+			"size": "800x1280",
+			"release": "10-2013"
+		},
+		{
+			"name": "galaxy nexus",
+			"platform": "android",
+			"os": "4.1.1",
+			"size": "360x598",
+			"release": "2011-11"
+		},
+		{
+			"name": "hp slate 7 2800",
+			"platform": "android",
+			"os": "4.1.1",
+			"size": "600x1024",
+			"release": "2013-06"
+		},
+		{
+			"name": "hp slate 21",
+			"platform": "android",
+			"os": "4.2.2",
+			"size": "1920xNA",
+			"release": "2013-10"
+		},
+		{
+			"name": "hp touchpad",
+			"platform": "android",
+			"os": "4.0.3",
+			"size": "768x1024",
+			"release": "2011-07"
+		},
+		{
+			"name": "hp touchpad",
+			"platform": "webos",
+			"os": "3.0",
+			"size": "768x1024",
+			"release": "2011-07"
+		},
+		{
+			"name": "hp veer",
+			"platform": "webos",
+			"os": "2.1.1",
+			"size": "320x545",
+			"release": "2011-06"
+		},
+		{
+			"name": "htc 7 mozart",
+			"platform": "wp7",
+			"os": "7.5",
+			"size": "320x480",
+			"release": "2010-10"
+		},
+		{
+			"name": "htc 7 trophy",
+			"platform": "wp7",
+			"os": "7.5",
+			"size": "320x480",
+			"release": "2010-10"
+		},
+		{
+			"name": "htc a620b",
+			"platform": "wp8",
+			"os": "8.0",
+			"size": "320x480",
+			"release": "2013-01"
+		},
+		{
+			"name": "htc desire",
+			"platform": "android",
+			"os": "2.3.3",
+			"size": "320x533",
+			"release": "2010-03"
+		},
+		{
+			"name": "htc desire c",
+			"platform": "android",
+			"os": "4.0.3",
+			"size": "320x480",
+			"release": "2012-06"
+		},
+		{
+			"name": "htc desire hd",
+			"platform": "android",
+			"os": "2.3.5",
+			"size": "320x533",
+			"release": "2010-10"
+		},
+		{
+			"name": "htc desire s",
+			"platform": "android",
+			"os": "4.0.4",
+			"size": "320x533",
+			"release": "2011-03"
+		},
+		{
+			"name": "htc desire x",
+			"platform": "android",
+			"os": "4.1.1",
+			"size": "320x533",
+			"release": "2012-10"
+		},
+		{
+			"name": "htc desire 700",
+			"platform": "android",
+			"os": "4.1.2",
+			"size": "360x640",
+			"release": "2014-01"
+		},
+		{
+			"name": "htc desire z (vision)",
+			"platform": "android",
+			"os": "2.2",
+			"size": "480x800",
+			"release": "2010-11"
+		},
+		{
+			"name": "htc droid eris",
+			"platform": "android",
+			"os": "2.1",
+			"size": "320x480",
+			"release": "2009-11"
+		},
+		{
+			"name": "htc evo 3d",
+			"platform": "android",
+			"os": "4.0.3",
+			"size": "540x960",
+			"release": "2011-07"
+		},
+		{
+			"name": "htc incredible 2",
+			"platform": "android ",
+			"os": "2.3.4",
+			"size": "320x533",
+			"release": "2011-04"
+		},
+		{
+			"name": "htc legend",
+			"platform": "android",
+			"os": "2.2",
+			"size": "320x480",
+			"release": "2010-03"
+		},
+		{
+			"name": "htc mytouch slide 4g",
+			"platform": "android",
+			"os": "2.3.4",
+			"size": "320x533",
+			"release": "2011-07"
+		},
+		{
+			"name": "htc one",
+			"platform": "android",
+			"os": "4.1.2",
+			"size": "360x640",
+			"release": "2013-03"
+		},
+		{
+			"name": "htc one mini",
+			"platform": "android",
+			"os": "4.2.2",
+			"size": "360x640",
+			"release": "2013-07"
+		},
+		{
+			"name": "htc one s",
+			"platform": "android",
+			"os": "4.0.3",
+			"size": "360x640",
+			"release": "2012-04"
+		},
+		{
+			"name": "htc one sv",
+			"platform": "android",
+			"os": "4.0.4",
+			"size": "320x533",
+			"release": "2012-12"
+		},
+		{
+			"name": "htc one v",
+			"platform": "android",
+			"os": "4.0.3",
+			"size": "320x533",
+			"release": "2012-04"
+		},
+		{
+			"name": "htc one x",
+			"platform": "android",
+			"os": "4.2.2",
+			"size": "360x640",
+			"release": "2012-05"
+		},
+		{
+			"name": "htc one x+",
+			"platform": "android",
+			"os": "4.3",
+			"size": "360x640",
+			"release": "2012-11"
+		},
+		{
+			"name": "htc one xl",
+			"platform": "android",
+			"os": "4.0.3",
+			"size": "360x640",
+			"release": "2012-05"
+		},
+		{
+			"name": "htc rio 8s",
+			"platform": "wp8",
+			"os": "8.0",
+			"size": "320x480",
+			"release": "2012-12"
+		},
+		{
+			"name": "htc sensation xl",
+			"platform": "android",
+			"os": "4.0.3",
+			"size": "360x640",
+			"release": "2011-11"
+		},
+		{
+			"name": "htc titan ii/4g",
+			"platform": "wp7",
+			"os": "7.5",
+			"size": "320x480",
+			"release": "2012-04"
+		},
+		{
+			"name": "htc velocity 4g",
+			"platform": "android",
+			"os": "4.0.3",
+			"size": "360x640",
+			"release": "2012-11"
+		},
+		{
+			"name": "htc wildfire a3333",
+			"platform": "android",
+			"os": "2.2.1",
+			"size": "267x356",
+			"release": "2010-05"
+		},
+		{
+			"name": "htc wildfire s",
+			"platform": "android",
+			"os": "2.3.3",
+			"size": "320x480",
+			"release": "2011-05"
+		},
+		{
+			"name": "htc windows phone 8s",
+			"platform": "wp8",
+			"os": "8.0",
+			"size": "320x480",
+			"release": "2012-11"
+		},
+		{
+			"name": "htc windows phone 8x (c625b)",
+			"platform": "wp8",
+			"os": "8.0",
+			"size": "320x480",
+			"release": "2012-11"
+		},
+		{
+			"name": "huawei ascend g510",
+			"platform": "android",
+			"os": "4.1.1",
+			"size": "320x569",
+			"release": "2013-04"
+		},
+		{
+			"name": "huawei ascend mate",
+			"platform": "android",
+			"os": "4.1.1",
+			"size": "480x813",
+			"release": "2013-03"
+		},
+		{
+			"name": "huawei u8650 sonic",
+			"platform": "android",
+			"os": "2.3.3",
+			"size": "320x480",
+			"release": "2011-06"
+		},
+		{
+			"name": "huawei u8860",
+			"platform": "android",
+			"os": "4.0.3",
+			"size": "320x544",
+			"release": "2011-12"
+		},
+		{
+			"name": "huawei y300-0151",
+			"platform": "android",
+			"os": "4.1.1",
+			"size": "320x533",
+			"release": "2013-03"
+		},
+		{
+			"name": "ipad",
+			"platform": "ios",
+			"os": "5.0.1",
+			"size": "768x1024",
+			"release": "2010-03"
+		},
+		{
+			"name": "ipad 2",
+			"platform": "ios",
+			"os": "5.0.1",
+			"size": "768x1024",
+			"release": "2011-03"
+		},
+		{
+			"name": "ipad 3",
+			"platform": "ios",
+			"os": "5.1.1",
+			"size": "768x1024",
+			"release": "2012-03"
+		},
+		{
+			"name": "ipad air",
+			"platform": "ios",
+			"os": "7.0.3",
+			"size": "768x1024",
+			"release": "2013-10"
+		},
+		{
+			"name": "ipad mini",
+			"platform": "ios",
+			"os": "6.0.1",
+			"size": "768x1024",
+			"release": "2012-11"
+		},
+		{
+			"name": "iphone",
+			"platform": "ios",
+			"os": "3.1.3",
+			"size": "320x480",
+			"release": "2007-06"
+		},
+		{
+			"name": "iphone 3g",
+			"platform": "ios",
+			"os": "4.2.1",
+			"size": "320x480",
+			"release": "2008-07"
+		},
+		{
+			"name": "iphone 3gs",
+			"platform": "ios",
+			"os": "6.0a2",
+			"size": "320x480",
+			"release": "2009-06"
+		},
+		{
+			"name": "iphone 4",
+			"platform": "ios",
+			"os": "5.1.1",
+			"size": "320x480",
+			"release": "2010-06"
+		},
+		{
+			"name": "iphone 4s",
+			"platform": "ios",
+			"os": "4.3.5",
+			"size": "320x480",
+			"release": "2011-10"
+		},
+		{
+			"name": "iphone 5",
+			"platform": "ios",
+			"os": "6.0",
+			"size": "320x568",
+			"release": "2012-09"
+		},
+		{
+			"name": "iphone 5c",
+			"platform": "ios",
+			"os": "7.0",
+			"size": "320x568",
+			"release": "2013-09"
+		},
+		{
+			"name": "iphone 5s",
+			"platform": "ios",
+			"os": "7.0",
+			"size": "320x568",
+			"release": "2013-09"
+		},
+		{
+			"name": "iphone 6",
+			"platform": "ios",
+			"os": "8.0",
+			"size": "375x667",
+			"release": "2014-09"
+		},
+		{
+			"name": "iphone 6 plus",
+			"platform": "ios",
+			"os": "8.0",
+			"size": "414x736",
+			"release": "2014-09"
+		},
+		{
+			"name": "ipod touch 4th gen",
+			"platform": "ios",
+			"os": "5.0.1",
+			"size": "320x480",
+			"release": "2010-09"
+		},
+		{
+			"name": "ipod touch 5th gen",
+			"platform": "ios",
+			"os": "6.0",
+			"size": "320x568",
+			"release": "2012-10"
+		},
+		{
+			"name": "kindle 3",
+			"platform": "kindle",
+			"os": "3.3",
+			"size": "600x-",
+			"release": "2010-08"
+		},
+		{
+			"name": "kindle fire 2",
+			"platform": "android",
+			"os": "4.0.3",
+			"size": "600x963",
+			"release": "2011-11"
+		},
+		{
+			"name": "kindle fire hd",
+			"platform": "android",
+			"os": "4",
+			"size": "533x801",
+			"release": "2012-09"
+		},
+		{
+			"name": "kindle fire hd 8.9",
+			"platform": "android",
+			"os": "4.0.3",
+			"size": "800x1220",
+			"release": "2012-10"
+		},
+		{
+			"name": "kindle paperwhite",
+			"platform": "kindle",
+			"os": "5",
+			"size": "758x-",
+			"release": "2012-10"
+		},
+		{
+			"name": "kobo ereader touch",
+			"platform": "android",
+			"os": "2.0.0",
+			"size": "600x-",
+			"release": "2011-06"
+		},
+		{
+			"name": "kogan 42&quot; smart 3d led tv",
+			"platform": "android",
+			"os": "4.1.2",
+			"size": "-x1280",
+			"release": "2013-07"
+		},
+		{
+			"name": "lenovo ideatab a1000",
+			"platform": "android",
+			"os": "4.2.2",
+			"size": "600x1024",
+			"release": "2013-05"
+		},
+		{
+			"name": "lenovo ideatab s6000",
+			"platform": "android",
+			"os": "4.2.2",
+			"size": "800x1280",
+			"release": "2013-06"
+		},
+		{
+			"name": "lenovo yoga tablet 8",
+			"platform": "android",
+			"os": "4.2.2",
+			"size": "602x962",
+			"release": "2013-10"
+		},
+		{
+			"name": "lenovo yoga tablet 10",
+			"platform": "android",
+			"os": "4.2.2",
+			"size": "800x1280",
+			"release": "2013-11"
+		},
+		{
+			"name": "lg 55lw6500 tv",
+			"platform": "proprietary (tv)",
+			"os": "5.00.07",
+			"size": "-x1280",
+			"release": "2011-03"
+		},
+		{
+			"name": "lg ally",
+			"platform": "android",
+			"os": "2.2.2",
+			"size": "320x533",
+			"release": "2010-04"
+		},
+		{
+			"name": "lg g2",
+			"platform": "android",
+			"os": "4.2.2",
+			"size": "360x598",
+			"release": "2013-09"
+		},
+		{
+			"name": "lg optimus 2x",
+			"platform": "android",
+			"os": "2.3.7",
+			"size": "320x533",
+			"release": "2011-02"
+		},
+		{
+			"name": "lg optimus black p970",
+			"platform": "android",
+			"os": "4.0.4",
+			"size": "320x533",
+			"release": "2011-05"
+		},
+		{
+			"name": "lg optimus g e975",
+			"platform": "android",
+			"os": "4.1.2",
+			"size": "384x640",
+			"release": "2012-11"
+		},
+		{
+			"name": "lg optimus l3 e400",
+			"platform": "android",
+			"os": "2.3.6",
+			"size": "320x427",
+			"release": "2012-02"
+		},
+		{
+			"name": "lg optimus l3 ii e425f",
+			"platform": "android",
+			"os": "4.1.2",
+			"size": "320x427",
+			"release": "2013-04"
+		},
+		{
+			"name": "lg optimus l7 p700",
+			"platform": "android",
+			"os": "4.0.3",
+			"size": "320x533",
+			"release": "2012-05"
+		},
+		{
+			"name": "lg optimus l9 p760",
+			"platform": "android",
+			"os": "4.0.4",
+			"size": "360x640",
+			"release": "2012-11"
+		},
+		{
+			"name": "lg optimus pad v900",
+			"platform": "android",
+			"os": "3.0.1",
+			"size": "768x1280",
+			"release": "2011-05"
+		},
+		{
+			"name": "lg viewty ku990",
+			"platform": "proprietary (java)",
+			"os": "1.2",
+			"size": "240x400",
+			"release": "2008-10"
+		},
+		{
+			"name": "microsoft surface",
+			"platform": "windows rt",
+			"os": "8.0",
+			"size": "768x1366",
+			"release": "2012-11"
+		},
+		{
+			"name": "microsoft surface pro",
+			"platform": "windows 8",
+			"os": "8.0",
+			"size": "720x1280",
+			"release": "2012-11"
+		},
+		{
+			"name": "motorola defy",
+			"platform": "android",
+			"os": "2.3.4",
+			"size": "320x569",
+			"release": "2010-10"
+		},
+		{
+			"name": "motorola defy mini",
+			"platform": "android",
+			"os": "2.3.6",
+			"size": "320x480",
+			"release": "2012-01"
+		},
+		{
+			"name": "motorola droid bionic",
+			"platform": "android",
+			"os": "4.1.2",
+			"size": "360x640",
+			"release": "2011-09"
+		},
+		{
+			"name": "motorola droid razr",
+			"platform": "android",
+			"os": "2.3.6",
+			"size": "360x640",
+			"release": "2011-11"
+		},
+		{
+			"name": "motorola droid 3",
+			"platform": "android",
+			"os": "2.3",
+			"size": "360x559",
+			"release": "2011-07"
+		},
+		{
+			"name": "motorola electrify 2",
+			"platform": "android",
+			"os": "4.1.2",
+			"size": "360x598",
+			"release": "2012-07"
+		},
+		{
+			"name": "motorola fire xt",
+			"platform": "android",
+			"os": "2.3.5",
+			"size": "320x480",
+			"release": "2011-09"
+		},
+		{
+			"name": "motorola flipout",
+			"platform": "android",
+			"os": "2.1",
+			"size": "320x240",
+			"release": "2010-06"
+		},
+		{
+			"name": "motorola milestone",
+			"platform": "android",
+			"os": "2.3.7",
+			"size": "320x569",
+			"release": "2009-11"
+		},
+		{
+			"name": "motorola moto g",
+			"platform": "android",
+			"os": "4.3",
+			"size": "360x598",
+			"release": "2013-11"
+		},
+		{
+			"name": "motorola razr hd 4g",
+			"platform": "android",
+			"os": "4.0.4",
+			"size": "360x598",
+			"release": "2012-09"
+		},
+		{
+			"name": "motorola razr m 4g",
+			"platform": "android",
+			"os": "4.0.4",
+			"size": "360x598",
+			"release": "2012-09"
+		},
+		{
+			"name": "motorola razr maxx",
+			"platform": "android",
+			"os": "4.0",
+			"size": "360x640",
+			"release": "2012-05"
+		},
+		{
+			"name": "motorola xoom",
+			"platform": "android",
+			"os": "4.1",
+			"size": "800x1280",
+			"release": "2011-05"
+		},
+		{
+			"name": "motorola xoom 2",
+			"platform": "android",
+			"os": "3.2.2",
+			"size": "800x1280",
+			"release": "2011-12"
+		},
+		{
+			"name": "motorola xoom 2 media edition",
+			"platform": "android",
+			"os": "3.2.2",
+			"size": "800x1280",
+			"release": "2011-12"
+		},
+		{
+			"name": "nexus 10",
+			"platform": "android",
+			"os": "4.2.2",
+			"size": "800x1280",
+			"release": "2012-11"
+		},
+		{
+			"name": "nexus 4",
+			"platform": "android",
+			"os": "4.2.1",
+			"size": "384x598",
+			"release": "2012-11"
+		},
+		{
+			"name": "nexus 5",
+			"platform": "android",
+			"os": "4.4",
+			"size": "360x598",
+			"release": "2013-10"
+		},
+		{
+			"name": "nexus 7",
+			"platform": "android",
+			"os": "4.1.1",
+			"size": "603x966",
+			"release": "2012-07"
+		},
+		{
+			"name": "nexus 7",
+			"platform": "android",
+			"os": "4.2.1",
+			"size": "600x961",
+			"release": "2012-07"
+		},
+		{
+			"name": "nexus 7",
+			"platform": "android",
+			"os": "4.3",
+			"size": "601x962",
+			"release": "2012-07"
+		},
+		{
+			"name": "nexus 7 (lcd density set to 175ppi)",
+			"platform": "android",
+			"os": "4.1.1",
+			"size": "731x1170",
+			"release": "2012-07"
+		},
+		{
+			"name": "nexus 7 (2013)",
+			"platform": "android",
+			"os": "4.3",
+			"size": "600x960",
+			"release": "2013-07"
+		},
+		{
+			"name": "nexus one",
+			"platform": "android",
+			"os": "2.3.7",
+			"size": "320x533",
+			"release": "2010-01"
+		},
+		{
+			"name": "nexus s",
+			"platform": "android",
+			"os": "4.1.1",
+			"size": "320x533",
+			"release": "2010-10"
+		},
+		{
+			"name": "nintendo 3ds",
+			"platform": "3ds",
+			"os": "4.3.0-10e",
+			"size": "416x-",
+			"release": "2011-02"
+		},
+		{
+			"name": "nintendo 3ds xl",
+			"platform": "3ds",
+			"os": "1.7455.eu",
+			"size": "416x-",
+			"release": "2012-07"
+		},
+		{
+			"name": "nintendo dsi",
+			"platform": "dsi",
+			"os": "507; u; en-gb",
+			"size": "256x-",
+			"release": "2009-04"
+		},
+		{
+			"name": "nintendo dsi xl",
+			"platform": "dsi",
+			"os": "1.4.4a",
+			"size": "240x-",
+			"release": "2010-03"
+		},
+		{
+			"name": "nintendo wii",
+			"platform": "wii",
+			"os": "4.3",
+			"size": "800x-",
+			"release": "2007-11"
+		},
+		{
+			"name": "nintendo wii u",
+			"platform": "wii u",
+			"os": "1.0.0.7494",
+			"size": "854x-",
+			"release": "2012-11"
+		},
+		{
+			"name": "nokia 2700",
+			"platform": "s40",
+			"os": "5th edition",
+			"size": "240x-",
+			"release": "2009-07"
+		},
+		{
+			"name": "nokia asha 300",
+			"platform": "proprietary (nokia)",
+			"os": "07.03 29-11-11 rm-781",
+			"size": "234x-",
+			"release": "2011-11"
+		},
+		{
+			"name": "nokia asha 302",
+			"platform": "proprietary (nokia)",
+			"os": "14.53 20-03-12 rm-813",
+			"size": "314x-",
+			"release": "2012-03"
+		},
+		{
+			"name": "nokia 500",
+			"platform": "symbian",
+			"os": "belle",
+			"size": "360x640",
+			"release": "2011-09"
+		},
+		{
+			"name": "nokia 700 (opera mobile)",
+			"platform": "symbian",
+			"os": "belle fp2",
+			"size": "240x427",
+			"release": "2011-09"
+		},
+		{
+			"name": "nokia e61i",
+			"platform": "s60",
+			"os": "symbian 9.1",
+			"size": "320x-",
+			"release": "2007-04"
+		},
+		{
+			"name": "nokia e71",
+			"platform": "s60",
+			"os": "symbian 9.2",
+			"size": "320x-",
+			"release": "2007-04"
+		},
+		{
+			"name": "nokia lumia 520",
+			"platform": "wp8",
+			"os": "8.0",
+			"size": "320x480",
+			"release": "2013-04"
+		},
+		{
+			"name": "nokia lumia 610",
+			"platform": "wp7",
+			"os": "7.5",
+			"size": "320x480",
+			"release": "2012-04"
+		},
+		{
+			"name": "nokia lumia 710",
+			"platform": "wp7",
+			"os": "7.5",
+			"size": "320x480",
+			"release": "2011-12"
+		},
+		{
+			"name": "nokia lumia 720",
+			"platform": "wp7",
+			"os": "8.0",
+			"size": "320x480",
+			"release": "2013-04"
+		},
+		{
+			"name": "nokia lumia 800",
+			"platform": "wp7",
+			"os": "7.5",
+			"size": "320x480",
+			"release": "2011-11"
+		},
+		{
+			"name": "nokia lumia 820",
+			"platform": "wp8",
+			"os": "8.0",
+			"size": "320x480",
+			"release": "2012-11"
+		},
+		{
+			"name": "nokia lumia 900",
+			"platform": "wp7",
+			"os": "7.5",
+			"size": "320x480",
+			"release": "2012-05"
+		},
+		{
+			"name": "nokia lumia 920",
+			"platform": "wp8",
+			"os": "8.0",
+			"size": "320x480",
+			"release": "2012-11"
+		},
+		{
+			"name": "nokia lumia 925",
+			"platform": "wp8",
+			"os": "8.0",
+			"size": "320x480",
+			"release": "2013-06"
+		},
+		{
+			"name": "nokia lumia 1520",
+			"platform": "wp8",
+			"os": "8.0",
+			"size": "320x480",
+			"release": "2013-11"
+		},
+		{
+			"name": "nokia n9",
+			"platform": "meego",
+			"os": "1.2",
+			"size": "320x496",
+			"release": "2011-09"
+		},
+		{
+			"name": "nokia n900",
+			"platform": "maemo",
+			"os": "5",
+			"size": "480x800",
+			"release": "2009-11"
+		},
+		{
+			"name": "nokia n95",
+			"platform": "s60",
+			"os": "symbian 9.2",
+			"size": "240x-",
+			"release": "2007-03"
+		},
+		{
+			"name": "palm pixi",
+			"platform": "webos",
+			"os": "1.4.5",
+			"size": "320x480",
+			"release": "2009-11"
+		},
+		{
+			"name": "palm pre",
+			"platform": "webos",
+			"os": "2.2",
+			"size": "320x-",
+			"release": "2009-10"
+		},
+		{
+			"name": "panasonic toughpad fz-a1",
+			"platform": "android",
+			"os": "4.0",
+			"size": "768x1024",
+			"release": "2012-12"
+		},
+		{
+			"name": "pendopad 7&quot;",
+			"platform": "android",
+			"os": "4.2.2",
+			"size": "480x800",
+			"release": "2013-11"
+		},
+		{
+			"name": "pendopad 10&quot;",
+			"platform": "android",
+			"os": "4.2.2",
+			"size": "600x1024",
+			"release": "2013-11"
+		},
+		{
+			"name": "pioneer dreambook",
+			"platform": "android",
+			"os": "4.0.4",
+			"size": "768x1024",
+			"release": "2010-07"
+		},
+		{
+			"name": "samsung ativ s",
+			"platform": "wp8",
+			"os": "8.0",
+			"size": "320x480",
+			"release": "2012-12"
+		},
+		{
+			"name": "samsung e3210",
+			"platform": "proprietary (java)",
+			"os": "-",
+			"size": "128x-",
+			"release": "2011-05"
+		},
+		{
+			"name": "samsung galaxy 5/europa i5500",
+			"platform": "android",
+			"os": "2.1-update1",
+			"size": "320x427",
+			"release": "2010-08"
+		},
+		{
+			"name": "samsung galaxy ace s5830",
+			"platform": "android",
+			"os": "2.3.4",
+			"size": "320x480",
+			"release": "2011-02"
+		},
+		{
+			"name": "samsung galaxy ace 2 i8160",
+			"platform": "android",
+			"os": "2.3.6",
+			"size": "320x533",
+			"release": "2012-05"
+		},
+		{
+			"name": "samsung galaxy ace plus s7500",
+			"platform": "android",
+			"os": "2.3.6",
+			"size": "320x480",
+			"release": "2012-02"
+		},
+		{
+			"name": "samsung galaxy beam i8530",
+			"platform": "android",
+			"os": "2.3.6",
+			"size": "320x533",
+			"release": "2012-07"
+		},
+		{
+			"name": "samsung galaxy camera gc100",
+			"platform": "android",
+			"os": "4.1.2",
+			"size": "360x598",
+			"release": "2012-11"
+		},
+		{
+			"name": "samsung galaxy mini s5570",
+			"platform": "android",
+			"os": "2.3.4",
+			"size": "240x320",
+			"release": "2011-02"
+		},
+		{
+			"name": "samsung galaxy mini 2 s6500",
+			"platform": "android",
+			"os": "2.3",
+			"size": "320x480",
+			"release": "2012-03"
+		},
+		{
+			"name": "samsung galaxy note n700",
+			"platform": "android",
+			"os": "2.3.6",
+			"size": "400x640",
+			"release": "2011-10"
+		},
+		{
+			"name": "samsung galaxy note 10.1 n8010",
+			"platform": "android",
+			"os": "4.0.4",
+			"size": "800x1280",
+			"release": "2012-08"
+		},
+		{
+			"name": "samsung galaxy note 10.1 n8010 (multiscreen enabled)",
+			"platform": "android",
+			"os": "4.0.4",
+			"size": "800x637",
+			"release": "2012-08"
+		},
+		{
+			"name": "samsung galaxy note 10.1 (2014 edition) p600",
+			"platform": "android",
+			"os": "4.3",
+			"size": "800x1280",
+			"release": "2013-11"
+		},
+		{
+			"name": "samsung galaxy note 2 n7100",
+			"platform": "android",
+			"os": "4.1.1",
+			"size": "360x640",
+			"release": "2012-09"
+		},
+		{
+			"name": "samsung galaxy note 3 n9005",
+			"platform": "android",
+			"os": "4.3",
+			"size": "360x640",
+			"release": "2013-09"
+		},
+		{
+			"name": "samsung galaxy note 8.0 n5100",
+			"platform": "android",
+			"os": "4.1.2",
+			"size": "601x962",
+			"release": "2013-04"
+		},
+		{
+			"name": "samsung galaxy note 8.0 n5110",
+			"platform": "android",
+			"os": "4.1.2",
+			"size": "601x962",
+			"release": "2013-04"
+		},
+		{
+			"name": "samsung galaxy s i9000",
+			"platform": "android",
+			"os": "2.3.6",
+			"size": "320x533",
+			"release": "2010-06"
+		},
+		{
+			"name": "samsung galaxy s duos s7562",
+			"platform": "android",
+			"os": "4.0.4",
+			"size": "320x533",
+			"release": "2012-09"
+		},
+		{
+			"name": "samsung galaxy s wifi ypg70cw",
+			"platform": "android",
+			"os": "2.2",
+			"size": "320x533",
+			"release": "2011-05"
+		},
+		{
+			"name": "samsung galaxy s2 i9100",
+			"platform": "android",
+			"os": "2.3.6",
+			"size": "320x533",
+			"release": "2011-04"
+		},
+		{
+			"name": "samsung galaxy s3 i9300",
+			"platform": "android",
+			"os": "4.0.4",
+			"size": "360x640",
+			"release": "2012-05"
+		},
+		{
+			"name": "samsung galaxy s3 mini i8190",
+			"platform": "android",
+			"os": "4.1.2",
+			"size": "320x533",
+			"release": "2012-11"
+		},
+		{
+			"name": "samsung galaxy s4 i9500",
+			"platform": "android",
+			"os": "4.2.2",
+			"size": "360x640",
+			"release": "2013-04"
+		},
+		{
+			"name": "samsung galaxy s4 i9505",
+			"platform": "android",
+			"os": "4.2.2",
+			"size": "360x640",
+			"release": "2013-04"
+		},
+		{
+			"name": "samsung galaxy s4 active i9295",
+			"platform": "android",
+			"os": "4.2.2",
+			"size": "360x640",
+			"release": "2013-06"
+		},
+		{
+			"name": "samsung galaxy s4 mini i9190",
+			"platform": "android",
+			"os": "4.2.2",
+			"size": "360x640",
+			"release": "2013-07"
+		},
+		{
+			"name": "samsung galaxy s4 zoom sm-c105",
+			"platform": "android",
+			"os": "4.2.2",
+			"size": "360x640",
+			"release": "2013-07"
+		},
+		{
+			"name": "samsung galaxy tab 10.1 p7510",
+			"platform": "android",
+			"os": "3.2",
+			"size": "800x1280",
+			"release": "2011-07"
+		},
+		{
+			"name": "samsung galaxy tab 2 10.1 p5110",
+			"platform": "android",
+			"os": "4.0.4",
+			"size": "800x1280",
+			"release": "2012-05"
+		},
+		{
+			"name": "samsung galaxy tab 2 7.0 p3110",
+			"platform": "android",
+			"os": "4.0.3",
+			"size": "600x1024",
+			"release": "2012-05"
+		},
+		{
+			"name": "samsung galaxy tab 3 7.0 t210",
+			"platform": "android",
+			"os": "4.1.2",
+			"size": "600x1024",
+			"release": "2013-07"
+		},
+		{
+			"name": "samsung galaxy tab 3 8.0 t310",
+			"platform": "android",
+			"os": "4.2.2",
+			"size": "602x962",
+			"release": "2013-07"
+		},
+		{
+			"name": "samsung galaxy tab 3 10.1 p5210",
+			"platform": "android",
+			"os": "4.2.2",
+			"size": "800x1280",
+			"release": "2013-07"
+		},
+		{
+			"name": "samsung galaxy tab 3 kids t2105",
+			"platform": "android",
+			"os": "4.1.2",
+			"size": "600x1024",
+			"release": "2013-11"
+		},
+		{
+			"name": "samsung galaxy tab 7.7 p6810",
+			"platform": "android",
+			"os": "3.2",
+			"size": "800x1280",
+			"release": "2012-01"
+		},
+		{
+			"name": "samsung galaxy tab 7.0 plus p6210",
+			"platform": "android",
+			"os": "3.2",
+			"size": "600x1024",
+			"release": "2012-01"
+		},
+		{
+			"name": "samsung galaxy tab 8.9 p7310",
+			"platform": "android",
+			"os": "4.0.4",
+			"size": "800x1280",
+			"release": "2011-05"
+		},
+		{
+			"name": "samsung galaxy tab 8.9 4g p7320",
+			"platform": "android",
+			"os": "3.2",
+			"size": "800x1280",
+			"release": "2012-02"
+		},
+		{
+			"name": "samsung galaxy tab p1000",
+			"platform": "android",
+			"os": "2.3.3",
+			"size": "400x683",
+			"release": "2010-10"
+		},
+		{
+			"name": "samsung galaxy x cover 2 s7710 ",
+			"platform": "android",
+			"os": "4.1.2",
+			"size": "320x533",
+			"release": "2013-03"
+		},
+		{
+			"name": "samsung galaxy y s5360",
+			"platform": "android",
+			"os": "2.3.6",
+			"size": "320x427",
+			"release": "2011-10"
+		},
+		{
+			"name": "samsung galaxy young s6310",
+			"platform": "android",
+			"os": "4.1.2",
+			"size": "320x480",
+			"release": "2013-02"
+		},
+		{
+			"name": "samsung infuse 4g i997",
+			"platform": "android",
+			"os": "2.3",
+			"size": "320x533",
+			"release": "2011-05"
+		},
+		{
+			"name": "samsung omnia w i8350",
+			"platform": "wp7",
+			"os": "7.5",
+			"size": "320x480",
+			"release": "2011-10"
+		},
+		{
+			"name": "samsung omnia 7 i8700",
+			"platform": "wp7",
+			"os": "7.5",
+			"size": "320x480",
+			"release": "2010-10"
+		},
+		{
+			"name": "samsung wave s8500",
+			"platform": "bada",
+			"os": "1.0",
+			"size": "240x400",
+			"release": "2010-04"
+		},
+		{
+			"name": "samsung wave s8500",
+			"platform": "bada",
+			"os": "2.0.1",
+			"size": "320x534",
+			"release": "2010-04"
+		},
+		{
+			"name": "scroll excel",
+			"platform": "android",
+			"os": "2.3.4",
+			"size": "480x800",
+			"release": "2012-02"
+		},
+		{
+			"name": "sony bravia 40 ex520",
+			"platform": "proprietary (tv)",
+			"os": "pkg4.012gaa-0104",
+			"size": "-x1920",
+			"release": "2011-01"
+		},
+		{
+			"name": "sony ericsson elm",
+			"platform": "proprietary (java)",
+			"os": "1231-1917 r7ca061 100619",
+			"size": "240x-",
+			"release": "2010-03"
+		},
+		{
+			"name": "sony ericsson spiro",
+			"platform": "proprietary (java)",
+			"os": "-",
+			"size": "240x-",
+			"release": "2010-08"
+		},
+		{
+			"name": "sony ericsson xperia arc",
+			"platform": "android",
+			"os": "2.3.4",
+			"size": "320x569",
+			"release": "2011-03"
+		},
+		{
+			"name": "sony ericsson xperia mini st15i",
+			"platform": "android",
+			"os": "2.3.4",
+			"size": "320x401",
+			"release": "2011-08"
+		},
+		{
+			"name": "sony ericsson xperia neo",
+			"platform": "android",
+			"os": "4.0.4",
+			"size": "480x854",
+			"release": "2011-03"
+		},
+		{
+			"name": "sony ericcson xperia play",
+			"platform": "android",
+			"os": "2.3.4",
+			"size": "425x974",
+			"release": "2011-03"
+		},
+		{
+			"name": "sony ericsson xperia x8",
+			"platform": "android",
+			"os": "2.1.1",
+			"size": "320x480",
+			"release": "2010-09"
+		},
+		{
+			"name": "sony ericsson xperia x10",
+			"platform": "android",
+			"os": "2.3.3",
+			"size": "320x569",
+			"release": "2010-03"
+		},
+		{
+			"name": "sony playstation 3",
+			"platform": "playstation 3",
+			"os": "4.25",
+			"size": "-x1824",
+			"release": "2006-11"
+		},
+		{
+			"name": "sony playstation portable",
+			"platform": "playstation portable",
+			"os": "4.2",
+			"size": "-x480",
+			"release": "2005-03"
+		},
+		{
+			"name": "sony playstation vita",
+			"platform": "playstation vita",
+			"os": "1.00",
+			"size": "-x896",
+			"release": "2012-02"
+		},
+		{
+			"name": "sony tablet p",
+			"platform": "android",
+			"os": "4.0.3",
+			"size": "-x1024",
+			"release": "2012-09"
+		},
+		{
+			"name": "sony tablet s",
+			"platform": "android",
+			"os": "4.0.3",
+			"size": "800x1280",
+			"release": "2011-09"
+		},
+		{
+			"name": "sony vaio tap 20",
+			"platform": "windows 8",
+			"os": "8.0",
+			"size": "900x1600",
+			"release": "2013-06"
+		},
+		{
+			"name": "sony xperia acro s",
+			"platform": "android",
+			"os": "4.0.4",
+			"size": "360x640",
+			"release": "2012-08"
+		},
+		{
+			"name": "sony xperia p",
+			"platform": "android",
+			"os": "2.3.7",
+			"size": "360x640",
+			"release": "2012-05"
+		},
+		{
+			"name": "sony xperia s",
+			"platform": "android",
+			"os": "2.3.7",
+			"size": "360x640",
+			"release": "2012-02"
+		},
+		{
+			"name": "sony xperia sola",
+			"platform": "android",
+			"os": "2.3.7",
+			"size": "320x569",
+			"release": "2012-05"
+		},
+		{
+			"name": "sony xperia sp",
+			"platform": "android",
+			"os": "4.1.2",
+			"size": "360x598",
+			"release": "2013-04"
+		},
+		{
+			"name": "sony xperia tablet z",
+			"platform": "android",
+			"os": "4.1.2",
+			"size": "800x1280",
+			"release": "2013-05"
+		},
+		{
+			"name": "sony xperia tipo",
+			"platform": "android",
+			"os": "4.0.4",
+			"size": "320x480",
+			"release": "2012-08"
+		},
+		{
+			"name": "sony xperia u",
+			"platform": "android",
+			"os": "2.3.7",
+			"size": "320x569",
+			"release": "2012-05"
+		},
+		{
+			"name": "sony xperia v",
+			"platform": "android",
+			"os": "4.1.2",
+			"size": "360x598",
+			"release": "2012-12"
+		},
+		{
+			"name": "sony xperia z",
+			"platform": "android",
+			"os": "4.1.2",
+			"size": "360x598",
+			"release": "2013-02"
+		},
+		{
+			"name": "sony xperia z1",
+			"platform": "android",
+			"os": "4.2.2",
+			"size": "360x598",
+			"release": "2013-09"
+		},
+		{
+			"name": "telstra t-hub 2",
+			"platform": "android",
+			"os": "2.3.7",
+			"size": "400x683",
+			"release": "2012-07"
+		},
+		{
+			"name": "tesco hudl",
+			"platform": "android",
+			"os": "4.2",
+			"size": "600x799",
+			"release": "2013-09"
+		},
+		{
+			"name": "toshiba at100",
+			"platform": "android",
+			"os": "4.0.4",
+			"size": "800x1280",
+			"release": "2011-07"
+		},
+		{
+			"name": "toshiba at1s0",
+			"platform": "android",
+			"os": "3.2",
+			"size": "602x961",
+			"release": "2012-02"
+		},
+		{
+			"name": "toshiba at200",
+			"platform": "android",
+			"os": "3.2.1",
+			"size": "800x1280",
+			"release": "2012-02"
+		},
+		{
+			"name": "toshiba at300",
+			"platform": "android",
+			"os": "4.0.3",
+			"size": "800x1280",
+			"release": "2012-06"
+		},
+		{
+			"name": "toshiba at330",
+			"platform": "android",
+			"os": "4.0.3",
+			"size": "900x1600",
+			"release": "2012-07"
+		},
+		{
+			"name": "wiko cink slim",
+			"platform": "android",
+			"os": "4.1.1",
+			"size": "320x533",
+			"release": "2012-11"
+		},
+		{
+			"name": "yarvik xenta tab 8c",
+			"platform": "android",
+			"os": "4.1.2",
+			"size": "768x1024",
+			"release": "2013-08"
+		},
+		{
+			"name": "xbox 360",
+			"platform": "xbox",
+			"os": "2.0",
+			"size": "-x1050",
+			"release": "2005-11"
+		},
+		{
+			"name": "xiaomi mi-3",
+			"platform": "android",
+			"os": "4.2.1",
+			"size": "360x640",
+			"release": "2013-09"
+		},
+		{
+			"name": "zte open",
+			"platform": "firefox os",
+			"os": "1.0.0b01",
+			"size": "320x415",
+			"release": "2013-07"
+		},
+		{
+			"name": "zte t22 (telstra urbane)",
+			"platform": "android",
+			"os": "4.0.4",
+			"size": "320x533",
+			"release": "2012-08"
+		},
+		{
+			"name": "zte t28 (telstra active touch)",
+			"platform": "android",
+			"os": "2.3.5",
+			"size": "320x533",
+			"release": "2011-05"
+		},
+		{
+			"name": "zte t760 (telstra smart-touch 2)",
+			"platform": "android",
+			"os": "2.3.5",
+			"size": "320x480",
+			"release": "2012-02"
+		},
+		{
+			"name": "zte t790 (telstra pulse)",
+			"platform": "android",
+			"os": "4.0.4",
+			"size": "320x480",
+			"release": "2013-05"
+		},
+		{
+			"name": "zte t81 (telstra frontier 4g)",
+			"platform": "android",
+			"os": "4.0.4",
+			"size": "320x533",
+			"release": "2012-11"
+		},
+		{
+			"name": "zte t82 (telstra easy touch 4g)",
+			"platform": "android",
+			"os": "4.0.4",
+			"size": "360x598",
+			"release": "2012-11"
+		},
+		{
+			"name": "zte t83 (telstra dave 4g)",
+			"platform": "android",
+			"os": "4.1.2",
+			"size": "320x534",
+			"release": "2013-10"
+		}
+	]
+}

--- a/index.js
+++ b/index.js
@@ -1,56 +1,31 @@
 'use strict';
-var url = require('url');
 var arrify = require('arrify');
-var getProxy = require('get-proxy');
-var got = require('got');
+var devices = require('./data.json').devices;
 
 module.exports = function (items) {
-	var opts = {json: true};
-	var proxy = getProxy();
-
 	items = arrify(items);
 
-	if (items.length) {
-		items = items.map(function (item) {
-			return item.split(' ').join('').toLowerCase();
-		});
+	if (!items.length) {
+		return devices;
 	}
 
-	if (proxy) {
-		opts.host = url.parse(proxy).hostname;
-		opts.port = url.parse(proxy).port;
-		opts.path = 'http://viewportsizes.com/devices.json';
-		opts.headers = {Host: 'http://viewportsizes.com/devices.json'};
-	}
-
-	return got('http://viewportsizes.com/devices.json', opts).then(function (res) {
-		var ret = [];
-		var sizes = res.body.map(function (size) {
-			return {
-				name: size['Device Name'].toLowerCase(),
-				platform: size.Platform.toLowerCase(),
-				os: size['OS Version'].toLowerCase(),
-				size: size['Portrait Width'] + 'x' + size['Landscape Width'],
-				release: size['Release Date']
-			};
-		});
-
-		if (!items.length) {
-			return sizes;
-		}
-
-		items.forEach(function (item) {
-			sizes.filter(function (size) {
-				return size.name.split(' ').join('').indexOf(item) !== -1;
-			}).forEach(function (size) {
-				ret.push(size);
-			});
-		});
-
-		if (!ret.length) {
-			throw new Error('Couldn\'t get any items');
-		}
-
-		return ret;
+	items = items.map(function (item) {
+		return item.split(' ').join('').toLowerCase();
 	});
+
+	var ret = [];
+
+	items.forEach(function (item) {
+		devices.filter(function (device) {
+			return device.name.split(' ').join('').indexOf(item) !== -1;
+		}).forEach(function (device) {
+			ret.push(device);
+		});
+	});
+
+	if (!ret.length) {
+		throw new Error('Couldn\'t get any items');
+	}
+
+	return ret;
 };

--- a/make.js
+++ b/make.js
@@ -1,0 +1,31 @@
+#!/usr/bin/env node
+'use strict';
+var fs = require('fs');
+var Promise = require('pinkie-promise');
+var pify = require('pify');
+var got = require('got');
+var fsP = pify(fs, Promise);
+
+got('viewportsizes.com/devices.json', {json: true})
+	.then(function (res) {
+		var devices = res.body.map(function (size) {
+			return {
+				name: size['Device Name'].toLowerCase(),
+				platform: size.Platform.toLowerCase(),
+				os: size['OS Version'].toLowerCase(),
+				size: size['Portrait Width'] + 'x' + size['Landscape Width'],
+				release: size['Release Date']
+			};
+		});
+
+		var data = {
+			timestamp: new Date(),
+			devices: devices
+		};
+
+		return fsP.writeFile('data.json', JSON.stringify(data, undefined, '\t'));
+	})
+	.catch(function (err) {
+		console.error(err);
+		process.exit(1);
+	});

--- a/package.json
+++ b/package.json
@@ -13,10 +13,12 @@
     "node": ">=0.10.0"
   },
   "scripts": {
-    "test": "xo && ava"
+    "test": "xo && ava",
+    "prepublish": "./make.js"
   },
   "files": [
-    "index.js"
+    "index.js",
+    "data.json"
   ],
   "keywords": [
     "device",
@@ -26,15 +28,13 @@
     "viewport"
   ],
   "dependencies": {
-    "arrify": "^1.0.0",
-    "get-proxy": "^1.0.0",
-    "get-stdin": "^4.0.1",
-    "got": "^4.1.1",
-    "meow": "^3.3.0",
-    "to-csv": "^0.1.0"
+    "arrify": "^1.0.0"
   },
   "devDependencies": {
     "ava": "*",
+    "got": "^5.6.0",
+    "pify": "^2.3.0",
+    "pinkie-promise": "^2.0.1",
     "xo": "*"
   }
 }

--- a/test.js
+++ b/test.js
@@ -8,15 +8,9 @@ test('return viewports', async t => {
 
 test('return all viewports', async t => {
 	const viewports = await fn();
-	t.ok(viewports.length > 50);
+	t.true(viewports.length > 50);
 });
 
-test('error when no viewports are found', async t => {
-	try {
-		await fn(['foobar']);
-		t.fail();
-	} catch (err) {
-		t.ok(err);
-		t.is(err.message, 'Couldn\'t get any items');
-	}
+test('error when no viewports are found', t => {
+	t.throws(fn.bind(undefined, ['foobar']), 'Couldn\'t get any items');
 });


### PR DESCRIPTION
As discussed here: https://github.com/sindresorhus/pageres/pull/258#issuecomment-225538217

Added `make.js` file that downloads and writes the `devices.json` file. The package does not try to load the data at runtime but just uses the cached version.

Something I thought about. Should we add a timestamp to the `json` file and check if the data is not older then a certain time. If it is older then (for instance) 2 months, show a warning to create an issue in this repository to update the data.

-------------------
Will do a :lipstick: PR after this one gets merged.


@sindresorhus 