### PR TITLE
merge custom data in makefile

### DIFF
--- a/data.json
+++ b/data.json
@@ -1,5 +1,5 @@
 {
-	"timestamp": "2016-08-31T15:14:07.470Z",
+	"timestamp": "2016-10-29T18:54:48.286Z",
 	"devices": [
 		{
 			"name": "acer iconia tab a1-810",
@@ -2002,6 +2002,20 @@
 			"os": "4.1.2",
 			"size": "320x534",
 			"release": "2013-10"
+		},
+		{
+			"name": "iphone 7",
+			"platform": "ios",
+			"os": "10.0",
+			"size": "375x667",
+			"release": "2016-09"
+		},
+		{
+			"name": "iphone 7 plus",
+			"platform": "ios",
+			"os": "10.0",
+			"size": "414x736",
+			"release": "2016-09"
 		}
 	]
 }

--- a/index.js
+++ b/index.js
@@ -1,16 +1,13 @@
 'use strict';
 const devices = require('./data').devices;
-const customDevices = require('./custom');
 
 module.exports = items => {
-	const list = devices.concat(customDevices);
-
 	if (items && !Array.isArray(items)) {
 		throw new Error(`Expected \`Array\`, got \`${typeof items}\``);
 	}
 
 	if (!items) {
-		return list;
+		return devices;
 	}
 
 	items = items.map(x => x.split(' ').join('').toLowerCase());
@@ -18,7 +15,7 @@ module.exports = items => {
 	let ret = [];
 
 	for (const x of items) {
-		ret = ret.concat(list.filter(y => y.name.split(' ').join('').includes(x)));
+		ret = ret.concat(devices.filter(y => y.name.split(' ').join('').includes(x)));
 	}
 
 	if (ret.length === 0) {

--- a/make.js
+++ b/make.js
@@ -3,6 +3,7 @@
 const fs = require('fs');
 const pify = require('pify');
 const got = require('got');
+const customData = require('./custom.json');
 
 const fsP = pify(fs);
 
@@ -18,7 +19,7 @@ got('viewportsizes.com/devices.json', {json: true})
 
 		const data = {
 			timestamp: new Date(),
-			devices
+			devices: devices.concat(customData)
 		};
 
 		return fsP.writeFile('data.json', JSON.stringify(data, undefined, '\t'));

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
   },
   "files": [
     "index.js",
-    "custom.json",
     "data.json"
   ],
   "keywords": [

--- a/test.js
+++ b/test.js
@@ -17,6 +17,6 @@ test('return all viewports', async t => {
 	t.true(m().length > 50);
 });
 
-test('have custom list of devices', async t => {
+test('custom devices', async t => {
 	t.is(m(['iphone 7']).length, 2);
 });


### PR DESCRIPTION
Instead of exposing 2 json files (`data.json` and `custom.json`), the custom data is now merged into `data.json`. The benefit is that we now only expose one json file and that people who want to use the json file directly only have to read one file instead of two.